### PR TITLE
feat: filter out-of-scope symlinks

### DIFF
--- a/files/listing.go
+++ b/files/listing.go
@@ -109,6 +109,8 @@ func (l byModified) Less(i, j int) bool {
 	return iModified.Sub(jModified) < 0
 }
 
+// FilterItems only includes items that return true when
+// ran through the provided function
 func (l *Listing) FilterItems(fn func(fi *FileInfo) bool) {
 	filtered := []*FileInfo{}
 	for _, item := range l.Items {


### PR DESCRIPTION
Do not list symlinks that target files out of scope of the user's root path.