### PR TITLE
feat: add Phrase In-Context Editor to staging builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,13 @@ build: | build-frontend build-backend ## Build binary
 build-frontend: ## Build frontend
 	cd frontend && pnpm install --frozen-lockfile && pnpm run build
 
+.PHONY: build-staging
+build-staging: | build-frontend-staging build-backend ## Build binary with Phrase ICE embedded (staging only, never production)
+
+.PHONY: build-frontend-staging
+build-frontend-staging: ## Build frontend with Phrase In-Context Editor (staging only)
+	cd frontend && pnpm install --frozen-lockfile && pnpm run build:staging
+
 .PHONY: build-backend
 build-backend: ## Build backend
 	$(go) build -ldflags '$(LDFLAGS)' -o .

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "pnpm run typecheck && vite build",
+    "build:staging": "pnpm run typecheck && vite build --mode staging",
     "clean": "find ./dist -maxdepth 1 -mindepth 1 ! -name '.gitkeep' -exec rm -r {} +",
     "typecheck": "vue-tsc -p ./tsconfig.app.json --noEmit",
     "lint": "eslint src/",

--- a/frontend/src/i18n/__tests__/phrase.test.ts
+++ b/frontend/src/i18n/__tests__/phrase.test.ts
@@ -98,6 +98,21 @@ describe("loadPhraseIce", () => {
     );
   });
 
+  it("clears the opt-in via ?phraseapp=disabled", async () => {
+    const phrase = await importPhrase("staging");
+    documentStub.cookie = "phraseapp=enabled";
+    locationStub.href = "https://staging.example.com/files/?phraseapp=disabled";
+
+    phrase.loadPhraseIce();
+
+    expect(documentStub.cookie).not.toContain("phraseapp=enabled");
+    expect(locationStub.replace).toHaveBeenCalledWith(
+      "https://staging.example.com/files/"
+    );
+    expect(window.PHRASEAPP_CONFIG).toBeUndefined();
+    expect(appendedScripts).toHaveLength(0);
+  });
+
   it("sets PHRASEAPP_CONFIG and injects the ICE script when opted in", async () => {
     const phrase = await importPhrase("staging");
     documentStub.cookie = "phraseapp=enabled";
@@ -139,9 +154,15 @@ describe("phrasePostTranslation", () => {
     );
   });
 
-  it("passes non-string messages through untouched", async () => {
+  it("passes non-string messages through untouched even when ready", async () => {
+    vi.useFakeTimers();
     const phrase = await importPhrase("staging");
+    documentStub.cookie = "phraseapp=enabled";
     const message = [{ type: "text" }];
+
+    phrase.loadPhraseIce();
+    appendedScripts[0].onload?.();
+    vi.advanceTimersByTime(1000);
 
     expect(phrase.phrasePostTranslation(message as never, "key")).toBe(message);
   });

--- a/frontend/src/i18n/__tests__/phrase.test.ts
+++ b/frontend/src/i18n/__tests__/phrase.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface ScriptStub {
+  type?: string;
+  async?: boolean;
+  src?: string;
+  onload?: () => void;
+}
+
+let appendedScripts: ScriptStub[];
+let documentStub: {
+  cookie: string;
+  body: object;
+  createElement: () => ScriptStub;
+  dispatchEvent: (event: unknown) => void;
+  head: { appendChild: (el: ScriptStub) => void };
+};
+let locationStub: { href: string; replace: ReturnType<typeof vi.fn> };
+
+beforeEach(() => {
+  appendedScripts = [];
+  documentStub = {
+    cookie: "",
+    body: {},
+    createElement: () => ({}) as ScriptStub,
+    dispatchEvent: () => {},
+    head: {
+      appendChild: (el: ScriptStub) => {
+        appendedScripts.push(el);
+      },
+    },
+  };
+  locationStub = {
+    href: "https://staging.example.com/files/",
+    replace: vi.fn(),
+  };
+  vi.stubGlobal("window", {
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    addEventListener: () => {},
+  });
+  vi.stubGlobal("document", documentStub);
+  vi.stubGlobal("location", locationStub);
+  vi.stubGlobal(
+    "MutationObserver",
+    class {
+      observe() {}
+      disconnect() {}
+    }
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// phraseIceEnabled is computed at module scope from import.meta.env.MODE, so
+// each case stubs the mode first and imports a fresh copy of the module.
+async function importPhrase(mode: string) {
+  vi.resetModules();
+  vi.stubEnv("MODE", mode);
+  return await import("../phrase");
+}
+
+describe("loadPhraseIce", () => {
+  it("does nothing outside staging builds", async () => {
+    const phrase = await importPhrase("production");
+    documentStub.cookie = "phraseapp=enabled";
+
+    expect(phrase.phraseIceEnabled).toBe(false);
+
+    phrase.loadPhraseIce();
+
+    expect(window.PHRASEAPP_CONFIG).toBeUndefined();
+    expect(appendedScripts).toHaveLength(0);
+  });
+
+  it("stays dormant until the translator opts in via cookie", async () => {
+    const phrase = await importPhrase("staging");
+
+    phrase.loadPhraseIce();
+
+    expect(window.PHRASEAPP_CONFIG).toBeUndefined();
+    expect(appendedScripts).toHaveLength(0);
+  });
+
+  it("persists the opt-in from ?phraseapp=enabled and cleans the url", async () => {
+    const phrase = await importPhrase("staging");
+    locationStub.href = "https://staging.example.com/files/?phraseapp=enabled";
+
+    phrase.loadPhraseIce();
+
+    expect(documentStub.cookie).toContain("phraseapp=enabled");
+    expect(locationStub.replace).toHaveBeenCalledWith(
+      "https://staging.example.com/files/"
+    );
+  });
+
+  it("sets PHRASEAPP_CONFIG and injects the ICE script when opted in", async () => {
+    const phrase = await importPhrase("staging");
+    documentStub.cookie = "phraseapp=enabled";
+
+    phrase.loadPhraseIce();
+
+    expect(window.PHRASEAPP_CONFIG).toMatchObject({
+      accountId: "3b42d924cc735b83fa5b486acb7ed6b9",
+      projectId: "f2d90a99ff37b4cf5ac4f3037eb394e3",
+      phraseEnabled: true,
+      prefix: "[[__",
+      suffix: "__]]",
+    });
+    expect(appendedScripts).toHaveLength(1);
+    expect(appendedScripts[0]).toMatchObject({
+      async: true,
+      type: "module",
+      src: "https://cdn.phrase.com/strings/plugins/editor/latest/ice/index.js",
+    });
+  });
+});
+
+describe("phrasePostTranslation", () => {
+  it("decorates translations only after the ICE script has loaded", async () => {
+    vi.useFakeTimers();
+    const phrase = await importPhrase("staging");
+    documentStub.cookie = "phraseapp=enabled";
+
+    phrase.loadPhraseIce();
+
+    // ICE's MutationObserver is not watching yet — no decoration
+    expect(phrase.phrasePostTranslation("Hello", "buttons.save")).toBe("Hello");
+
+    appendedScripts[0].onload?.();
+    vi.advanceTimersByTime(1000);
+
+    expect(phrase.phrasePostTranslation("Hello", "buttons.save")).toBe(
+      "[[__phrase_buttons.save__]]"
+    );
+  });
+
+  it("passes non-string messages through untouched", async () => {
+    const phrase = await importPhrase("staging");
+    const message = [{ type: "text" }];
+
+    expect(phrase.phrasePostTranslation(message as never, "key")).toBe(message);
+  });
+});

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -18,6 +18,12 @@ import("dayjs/locale/zh-cn");
 // at once using the import syntax
 import messages from "@intlify/unplugin-vue-i18n/messages";
 
+import {
+  loadPhraseIce,
+  phraseIceEnabled,
+  phrasePostTranslation,
+} from "./phrase";
+
 export function detectLocale() {
   // locale is an RFC 5646 language tag
   // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language
@@ -90,12 +96,15 @@ export function detectLocale() {
 
 export const rtlLanguages = ["ar_AR"];
 
+loadPhraseIce();
+
 export const i18n = createI18n({
   locale: detectLocale(),
   fallbackLocale: "en_GB",
   messages,
   // expose i18n.global for outside components
   legacy: true,
+  ...(phraseIceEnabled ? { postTranslation: phrasePostTranslation } : {}),
 });
 
 export const isRtl = (locale?: string) => {

--- a/frontend/src/i18n/phrase.ts
+++ b/frontend/src/i18n/phrase.ts
@@ -1,0 +1,145 @@
+import { ref } from "vue";
+import type { PostTranslationHandler, VueMessageType } from "vue-i18n";
+
+// Phrase In-Context Editor (ICE) integration.
+//
+// ICE is compiled in only by the staging build (`pnpm run build:staging`,
+// i.e. `vite build --mode staging`) — the production build must never
+// include it, because translators edit live on top of the staging
+// deployment only. The ids below are not secrets: they are served to every
+// visitor of the staging deployment as part of PHRASEAPP_CONFIG.
+//
+// Even on staging, ICE stays dormant until a translator opts in by visiting
+// any page with ?phraseapp=enabled (persisted in a cookie for a week;
+// ?phraseapp=disabled clears it again).
+
+const COOKIE_NAME = "phraseapp";
+const ONE_WEEK = 7 * 24 * 60 * 60;
+
+const phraseAccountId = "3b42d924cc735b83fa5b486acb7ed6b9";
+const phraseProjectId = "f2d90a99ff37b4cf5ac4f3037eb394e3";
+
+const phrasePrefix = "[[__";
+const phraseSuffix = "__]]";
+const phraseIceScriptUrl =
+  "https://cdn.phrase.com/strings/plugins/editor/latest/ice/index.js";
+
+interface PhraseAppConfig {
+  accountId: string;
+  projectId: string;
+  phraseEnabled: boolean;
+  fullReparse: boolean;
+  prefix: string;
+  suffix: string;
+  autoLowercase: boolean;
+}
+
+declare global {
+  interface Window {
+    PHRASEAPP_CONFIG?: PhraseAppConfig;
+  }
+}
+
+export const phraseIceEnabled = import.meta.env.MODE === "staging";
+
+// Flips only after the CDN script has initialised its MutationObserver —
+// markers rendered before ICE is watching never get edit bubbles attached.
+// Reading it inside phrasePostTranslation (i.e. during component render)
+// makes Vue track it, so flipping it re-renders all translated components.
+const phraseIceReady = ref(false);
+
+function applyUrlParam() {
+  const url = new URL(location.href);
+  const param = url.searchParams.get(COOKIE_NAME);
+  if (param !== "enabled" && param !== "disabled") return;
+
+  if (param === "enabled") {
+    document.cookie = `${COOKIE_NAME}=enabled; max-age=${ONE_WEEK}; path=/`;
+  } else {
+    document.cookie = `${COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+  }
+  url.searchParams.delete(COOKIE_NAME);
+  location.replace(url.toString());
+}
+
+function hasCookie(cookie: string) {
+  return document.cookie.split(";").some((c) => c.trim() === cookie);
+}
+
+export function loadPhraseIce() {
+  if (!phraseIceEnabled) return;
+
+  applyUrlParam();
+
+  if (!hasCookie(`${COOKIE_NAME}=enabled`)) return;
+
+  window.PHRASEAPP_CONFIG = {
+    accountId: phraseAccountId,
+    projectId: phraseProjectId,
+    phraseEnabled: true,
+    fullReparse: true,
+    prefix: phrasePrefix,
+    suffix: phraseSuffix,
+    autoLowercase: false,
+  };
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.type = "module";
+  script.src = phraseIceScriptUrl;
+  script.onload = () => {
+    setTimeout(() => {
+      phraseIceReady.value = true;
+      triggerIceRescanOnDomChange();
+    }, 1000);
+  };
+  document.head.appendChild(script);
+}
+
+// ICE only re-scans the document from its own (throttled, capturing) scroll
+// listener — its MutationObserver ignores added nodes and text changes. Any
+// page change without a scroll (route change, async file listing, resize)
+// would leave edit bubbles frozen at stale coordinates, so synthesise a
+// scroll event whenever the DOM might have shifted.
+function triggerIceRescanOnDomChange() {
+  let timer: number | null = null;
+  const trigger = () => {
+    if (timer !== null) return;
+    timer = window.setTimeout(() => {
+      timer = null;
+      document.dispatchEvent(new Event("scroll"));
+    }, 200);
+  };
+
+  new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      if (
+        (m.type === "childList" && m.addedNodes.length > 0) ||
+        m.type === "characterData"
+      ) {
+        trigger();
+        return;
+      }
+    }
+  }).observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  });
+
+  if (typeof ResizeObserver !== "undefined") {
+    new ResizeObserver(trigger).observe(document.body);
+  }
+
+  window.addEventListener("resize", trigger, { passive: true });
+}
+
+// ICE looks for keys decorated as [[__phrase_<key>__]] in the rendered DOM
+// and overlays its editor on top of them.
+export const phrasePostTranslation: PostTranslationHandler<VueMessageType> = (
+  translated,
+  key
+) =>
+  phraseIceReady.value && typeof translated === "string"
+    ? `${phrasePrefix}phrase_${key}${phraseSuffix}`
+    : translated;

--- a/frontend/src/i18n/phrase.ts
+++ b/frontend/src/i18n/phrase.ts
@@ -114,7 +114,8 @@ function triggerIceRescanOnDomChange() {
   new MutationObserver((mutations) => {
     for (const m of mutations) {
       if (
-        (m.type === "childList" && m.addedNodes.length > 0) ||
+        (m.type === "childList" &&
+          (m.addedNodes.length > 0 || m.removedNodes.length > 0)) ||
         m.type === "characterData"
       ) {
         trigger();


### PR DESCRIPTION
Embeds the [Phrase In-Context Editor](https://support.phrase.com/hc/en-us/articles/5784095916188) (ICE) so translators can edit strings in place on the staging deployment.

The frontend compiles into a single binary, so ICE is included or excluded at build time:

| Command | ICE |
|---|---|
| `make build` | eliminated from the bundle entirely |
| `make build-staging` (new) | compiled in |

Even in the staging build, ICE stays dormant until opted in per browser via `?phraseapp=enabled` (week-long cookie; `?phraseapp=disabled` clears it). Translation keys are decorated via a vue-i18n `postTranslation` hook only after the ICE script has initialised (markers rendered earlier never get edit bubbles), and a synthetic scroll is dispatched on DOM changes so ICE repositions its edit overlays.

Verified: the production bundle contains zero references to Phrase; the staging bundle includes the integration; unit tests cover the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a staging build option for the frontend and full application.
  * Introduced staging-only Phrase In-Context Editor support for translation review.
  * Added an opt-in/out flow via URL parameter, with the choice persisted in a cookie for one week.

* **Tests**
  * Added automated coverage for staging activation, opt-in/out behavior, editor script loading, and translation decoration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->